### PR TITLE
Use string instead of text for prop types.

### DIFF
--- a/ampersand-file-drop-view.js
+++ b/ampersand-file-drop-view.js
@@ -24,8 +24,8 @@ var FileState = State.extend({
 	},
 	props: {
 		size: "number",
-		name: "text",
-		type: "text",
+		name: "string",
+		type: "string",
 		file: "any",
 		preview: "string"
 	}


### PR DESCRIPTION
"text" is not a valid type and has been silently ignored until ampersand-state 4.8.0.  See AmpersandJS/ampersand-state@9e80ea746e9cf80c4f27c0b83e3dacc41137f59a for details.